### PR TITLE
Add GPT insight generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ After installing dependencies you can run the unit tests with:
 pytest
 ```
 
+## Environment Variables
+
+Some features use the OpenAI API to generate insights. Set the `OPENAI_API_KEY`
+environment variable with a valid API key before running the report scripts if
+you want to enable this functionality.
+
 When generating a monthly bitácora report through the GUI you can now choose
 how many complete months to compare (between 2 and the number of detected
 months). Use the spinbox in the Bitácora configuration section to select the

--- a/data_processing/orchestrators.py
+++ b/data_processing/orchestrators.py
@@ -31,6 +31,7 @@ from .report_sections import (
 
 # Importaciones de módulos en la raíz del proyecto
 from config import numeric_internal_cols
+from gpt_analysis import generate_gpt_insights
 
 # Variable global para mensajes de resumen específicos de este módulo
 log_summary_messages_orchestrator = []
@@ -188,6 +189,14 @@ def procesar_reporte_rendimiento(input_files, output_dir, output_filename, statu
             if log_summary_messages_orchestrator: [log(f"  - {re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip().replace('---','-')}") for msg in log_summary_messages_orchestrator if re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip()]
             else: log("  No se generaron mensajes de resumen.")
             log("============================================================")
+
+            metrics_summary = "\n".join(log_summary_messages_orchestrator[-5:])
+            gpt_text = generate_gpt_insights(metrics_summary)
+            if gpt_text:
+                log("\n--- Análisis Inteligente ---")
+                for line in gpt_text.splitlines():
+                    log(line)
+
             log("\n\n--- FIN DEL REPORTE RENDIMIENTO ---",importante=True); status_queue.put("---DONE---")
 
             try:
@@ -618,6 +627,18 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
             if log_summary_messages_orchestrator: [log(f"  - {re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip().replace('---','-')}") for msg in log_summary_messages_orchestrator if re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip()]
             else: log("  No se generaron mensajes de resumen.")
             log("============================================================")
+
+            try:
+                metrics_summary = df_daily_total_for_bitacora.tail(3).to_csv(sep=';', index=False)
+            except Exception:
+                metrics_summary = "\n".join(log_summary_messages_orchestrator[-5:])
+
+            gpt_text = generate_gpt_insights(metrics_summary)
+            if gpt_text:
+                log("\n--- Análisis Inteligente ---")
+                for line in gpt_text.splitlines():
+                    log(line)
+
             log(f"\n\n--- FIN DEL REPORTE BITÁCORA ({bitacora_comparison_type}) ---", importante=True); status_queue.put("---DONE---")
 
             try:

--- a/gpt_analysis.py
+++ b/gpt_analysis.py
@@ -1,0 +1,32 @@
+import os
+from typing import Optional
+
+try:
+    import openai
+except ImportError:  # handle missing openai
+    openai = None
+
+
+def generate_gpt_insights(text: str) -> str:
+    """Return a short GPT-generated summary for the provided text."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key or not text or not openai:
+        return ""
+    try:
+        openai.api_key = api_key
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "Resume brevemente el texto proporcionado destacando puntos clave.",
+                },
+                {"role": "user", "content": text},
+            ],
+            temperature=0.2,
+            max_tokens=150,
+        )
+        choice = response.choices[0].message
+        return choice.get("content", "").strip()
+    except Exception:
+        return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openpyxl
 tkcalendar
 sv-ttk
 pytest
+openai


### PR DESCRIPTION
## Summary
- integrate OpenAI support via new gpt_analysis module
- call GPT insights from orchestrators after log summaries
- document `OPENAI_API_KEY` environment variable
- require `openai` in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812ea22ae48332a286215756ae5c43